### PR TITLE
Refactored the statistics module to avoid using the density

### DIFF
--- a/src/modules/plot_statistics.py
+++ b/src/modules/plot_statistics.py
@@ -5,69 +5,23 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-def get_densities() -> set:
-
-    """
-    Gathers values for densities used in MD calculations from the filenames
-    of '.dat' MD result files.
-
-    Returns
-    -------
-    set
-        A set containing all of the unique densities found in the CWD.
-    """
-
-    # Gathering all of the possible result files
-    dat_files = [fil for fil in os.listdir() if fil.endswith(".dat")]
-    dens_list = []
-
-    for fil in dat_files:
-
-        # This try block is to filter non-compatible files, as incompatible
-        # files will raise a ValueError and they can just be ignored.
-        try:
-            # Getting the index of the hyphen in the filename
-            ini = fil.index("-")
-
-            # Getting the index of the dot in the filename
-            dot = fil.index(".")
-
-            # Slicing the filename to get the density as a string
-            dens = fil[ini + 1 : dot]
-
-            # Getting the middle part of the density string to be able to
-            # add a dot
-            mid = round(len(dens) / 2)
-            dens = float(dens[:mid] + "." + dens[mid:])
-
-            # Saving the formatted density in a list
-            dens_list.append(dens)
-
-        # The index method raises an error if the string is not found. We want
-        # to ignore files that don't have the desired string.
-        except ValueError:
-            pass
-
-    # Converting the list into a set to remove repeated densities.
-    dens_list = set(dens_list)
-
-    return dens_list
-
-
 class MDSimulation:
     """
     Object that contains the results of a Molecular Dynamics simulation.
     """
 
-    RDF_NAME = "radial_dist"
-    MSD_NAME = "mean_square_displ"
-    ENE_NAME = "energies_per_atom"
+    RDF_NAME = "rdf"
+    TMP_NAME = "temperature"
+    PRE_NAME = "pressure"
+    ENE_NAME = "energy"
     F_EXTENS = ".dat"
+    OUT_PATH = "./output/"
 
-    def __init__(self, density: float):
+    def __init__(self):
 
+        # TODO: Remove this when I can confirm this is not needed anymore
         # Making the density available in the entire Class
-        self.dens = density
+        # self.dens = density
 
         # Matplotlib stylesheet which includes colorblind-friendly colors.
         plt.style.use("seaborn-colorblind")
@@ -99,6 +53,8 @@ class MDSimulation:
         self._result_folder()
 
         # Plotting
+        self._plot_temperature()
+        self._plot_pressure()
         self._plot_energies()
         self._plot_rdf()
         # self._plot_msd()
@@ -110,39 +66,50 @@ class MDSimulation:
         values into numpy arrays. These arrays are made available in the
         MDSimulation class with the following objects:
 
-        - self.rdf_results
+        - self.temp_results
         - self.energ_results
+        - self.press_results
+        - self.rdf_results
         - self.msd_results
 
         """
 
+        # TODO: Remove this later.
         # Filename treatment to be able to insert the density into the
         # filename, so results can be worked with iteratively.
-        den_str = str(self.dens).replace(".", "")
-        rdf = self.RDF_NAME + f"-{den_str}" + self.F_EXTENS
-        ene = self.ENE_NAME + f"-{den_str}" + self.F_EXTENS
-        msd = self.MSD_NAME + f"-{den_str}" + self.F_EXTENS
+        # den_str = str(self.dens).replace(".", "")
+        # rdf = self.RDF_NAME + f"-{den_str}" + self.F_EXTENS
+        # ene = self.ENE_NAME + f"-{den_str}" + self.F_EXTENS
+        # msd = self.MSD_NAME + f"-{den_str}" + self.F_EXTENS
 
-        # Loading the different results into an array
-        self.rdf_results = np.loadtxt(rdf)
+        temp = self.TMP_NAME + self.F_EXTENS
+        ene = self.ENE_NAME + self.F_EXTENS
+        press = self.PRE_NAME + self.F_EXTENS
+        rdf = self.RDF_NAME + self.F_EXTENS
+
+        # Loading the different results obtained in the MD simulation
+        # into several arrays.
+        self.temp_results = np.loadtxt(temp)
         self.energ_results = np.loadtxt(ene)
+        self.press_results = np.loadtxt(press)
+        self.rdf_results = np.loadtxt(rdf)
         # self.msd_results = np.loadtxt(msd)
 
     def _result_folder(self):
 
         """
-        Creates a timestamped folder in the CWD to store plots.
+        Creates a timestamped folder in the output folder to store the plots.
         """
 
         # Getting the current time
         current_time = time.strftime("%d-%m_%H-%M")
 
         # Timestamped folder name
-        self.fold_name = f"results_{current_time}"
+        self.fold_name = f"plots_{current_time}"
 
         # Creating the folder if the folder does not already exist
         if self.fold_name not in os.listdir():
-            os.mkdir(self.fold_name)
+            os.mkdir(self.OUT_PATH + self.fold_name)
 
     def _plot_rdf(self):
 
@@ -161,7 +128,55 @@ class MDSimulation:
         # Preparing a filename for the RSD plot image.
         den_str = str(self.dens).replace(".", "")
         filename = (
-            self.fold_name + "/" + self.RDF_NAME + f"_{den_str}_" + "plot.png"
+            self.OUT_PATH + self.fold_name + "/" + self.RDF_NAME + "plot.png"
+        )
+
+        # Saving the image and clearing the current plot.
+        plt.savefig(filename)
+        plt.clf()
+
+    def _plot_temperature(self):
+
+        """
+        Plots the temperature as a function of time using the results gathered
+        from the MD simulation.
+        The plots are stored in the ./output/results_%d-%m_%H-%M directory.
+        """
+
+        # Plotting the Temperature
+        plt.plot(self.temp_results[:, 0], self.temp_results[:, 1])
+        plt.title("Temperature")
+        plt.xlabel("Time []")
+        plt.ylabel("T [K]")
+
+        # Preparing a path for the T plot image.
+        den_str = str(self.dens).replace(".", "")
+        filename = (
+            self.OUT_PATH + self.fold_name + "/" + self.TMP_NAME + "plot.png"
+        )
+
+        # Saving the image and clearing the current plot.
+        plt.savefig(filename)
+        plt.clf()
+
+    def _plot_pressure(self):
+
+        """
+        Plots the pressure as a function of time using the results gathered
+        from the MD simulation.
+        The plots are stored in the ./output/results_%d-%m_%H-%M directory.
+        """
+
+        # Plotting the pressure
+        plt.plot(self.press_results[:, 0], self.press_results[:, 1])
+        plt.title("Pressure")
+        plt.xlabel("Time []")
+        plt.ylabel("Pressure []")
+
+        # Preparing a path for the P plot image.
+        den_str = str(self.dens).replace(".", "")
+        filename = (
+            self.OUT_PATH + self.fold_name + "/" + self.PRE_NAME + "plot.png"
         )
 
         # Saving the image and clearing the current plot.
@@ -185,7 +200,7 @@ class MDSimulation:
         # Preparing a filename for the MSD plot image.
         den_str = str(self.dens).replace(".", "")
         filename = (
-            self.fold_name + "/" + self.MSD_NAME + f"_{den_str}_" + "plot.png"
+            self.OUT_PATH + self.fold_name + "/" + self.MSD_NAME + "plot.png"
         )
 
         # Saving the image and clearing the current plot.
@@ -207,11 +222,10 @@ class MDSimulation:
         """
 
         # Preparing filenames for the plot images
-        den_str = str(self.dens).replace(".", "")
-        n_pot = self.fold_name + "/" + "ene-pot" + f"_{den_str}_" + "plot.png"
-        n_kin = self.fold_name + "/" + "ene-kin" + f"_{den_str}_" + "plot.png"
-        n_tot = self.fold_name + "/" + "ene-tot" + f"_{den_str}_" + "plot.png"
-        n_all = self.fold_name + "/" + "ene-all" + f"_{den_str}_" + "plot.png"
+        n_pot = self.OUT_PATH + self.fold_name + "/ene-pot" + "plot.png"
+        n_kin = self.OUT_PATH + self.fold_name + "/ene-kin" + "plot.png"
+        n_tot = self.OUT_PATH + self.fold_name + "/ene-tot" + "plot.png"
+        n_all = self.OUT_PATH + self.fold_name + "/ene-all" + "plot.png"
 
         # Names for the x and y axis
         x_lab = "Time"
@@ -219,7 +233,7 @@ class MDSimulation:
 
         # Preparing the plot for the potential energy
         plt.plot(self.energ_results[:, 0], self.energ_results[:, 1])
-        plt.title(f"Potential energy for ρ = {self.dens}")
+        plt.title(f"Potential energy")
         plt.xlabel(x_lab)
         plt.ylabel(y_lab)
 
@@ -229,7 +243,7 @@ class MDSimulation:
 
         # Preparing the plot for the kinetic energy
         plt.plot(self.energ_results[:, 0], self.energ_results[:, 2])
-        plt.title(f"Kinetic energy for ρ = {self.dens}")
+        plt.title(f"Kinetic energy")
         plt.xlabel(x_lab)
         plt.ylabel(y_lab)
 
@@ -239,7 +253,7 @@ class MDSimulation:
 
         # Preparing the plot for the total energy
         plt.plot(self.energ_results[:, 0], self.energ_results[:, 3])
-        plt.title(f"Total energy for ρ = {self.dens}")
+        plt.title(f"Total energy")
         plt.xlabel(x_lab)
         plt.ylabel(y_lab)
 
@@ -264,7 +278,7 @@ class MDSimulation:
             label="Total Energy",
         )
 
-        plt.title(f"All energies for ρ = {self.dens}")
+        plt.title(f"All energies")
         plt.legend()
         plt.xlabel(x_lab)
         plt.ylabel(y_lab)
@@ -274,8 +288,62 @@ class MDSimulation:
         plt.clf()
 
 
+# def get_densities() -> set:
+
+#     """
+#     Gathers values for densities used in MD calculations from the filenames
+#     of '.dat' MD result files.
+
+#     Returns
+#     -------
+#     set
+#         A set containing all of the unique densities found in the CWD.
+#     """
+
+#     # Gathering all of the possible result files
+#     dat_files = [fil for fil in os.listdir() if fil.endswith(".dat")]
+#     dens_list = []
+
+#     for fil in dat_files:
+
+#         # This try block is to filter non-compatible files, as incompatible
+#         # files will raise a ValueError and they can just be ignored.
+#         try:
+#             # Getting the index of the hyphen in the filename
+#             ini = fil.index("-")
+
+#             # Getting the index of the dot in the filename
+#             dot = fil.index(".")
+
+#             # Slicing the filename to get the density as a string
+#             dens = fil[ini + 1 : dot]
+
+#             # Getting the middle part of the density string to be able to
+#             # add a dot
+#             mid = round(len(dens) / 2)
+#             dens = float(dens[:mid] + "." + dens[mid:])
+
+#             # Saving the formatted density in a list
+#             dens_list.append(dens)
+
+#         # The index method raises an error if the string is not found. We want
+#         # to ignore files that don't have the desired string.
+#         except ValueError:
+#             pass
+
+#     # Converting the list into a set to remove repeated densities.
+#     dens_list = set(dens_list)
+
+#     return dens_list
+
+
 if __name__ == "__main__":
-    dens_list = get_densities()
-    for dens in dens_list:
-        sim = MDSimulation(dens)
-        sim.generate_plots()
+
+    sim = MDSimulation()
+    sim.generate_plots()
+
+    # TODO: Previous iteration of the code. Delete this later.
+    # dens_list = get_densities()
+    # for dens in dens_list:
+    #    sim = MDSimulation(dens)
+    #    sim.generate_plots()


### PR DESCRIPTION
The statistics module should now work independently of the density, as only one density will be used during calculations.
Additionally, plots for the pressure and temperature have been added.

**Some of the changes made:**

- Removed a function for gathering all of the densities found in the results.
- Added plots for P and T.
- Changed the output folder path.
- Removed density from file names.